### PR TITLE
Add handling a string response

### DIFF
--- a/pymisp/api.py
+++ b/pymisp/api.py
@@ -206,7 +206,7 @@ class PyMISP(object):
             raise PyMISPError('Unknown error: {}'.format(response.text))
 
         errors = []
-        if isinstance(to_return, list):
+        if isinstance(to_return, (list, str)):
             to_return = {'response': to_return}
         if to_return.get('error'):
             if not isinstance(to_return['error'], list):


### PR DESCRIPTION
To avoid AttributeError when variable to_return is a string with a value "Pull queued for background execution."